### PR TITLE
optimize trimming suffix '\r\n' of string

### DIFF
--- a/redis/parser/parser.go
+++ b/redis/parser/parser.go
@@ -226,8 +226,7 @@ func parseBulkHeader(msg []byte, state *readState) error {
 }
 
 func parseSingleLineReply(msg []byte) (redis.Reply, error) {
-	str := strings.TrimSuffix(string(msg), "\n")
-	str = strings.TrimSuffix(str, "\r")
+	str := strings.TrimSuffix(string(msg), "\r\n")
 	var result redis.Reply
 	switch msg[0] {
 	case '+': // status reply


### PR DESCRIPTION
`readLine` function could make sure that `msg` variable ends with `"\r\n"`. So, I think `str := strings.TrimSuffix(string(msg), "\n"); str = strings.TrimSuffix(str, "\r")` and `str := strings.TrimSuffix(string(msg), "\r\n")` have a same result, but the latter is better way.