### PR TITLE
fix: goroutine leak in Wait

### DIFF
--- a/lib/sync/wait/wait.go
+++ b/lib/sync/wait/wait.go
@@ -28,7 +28,7 @@ func (w *Wait) Wait() {
 // WaitWithTimeout blocks until the WaitGroup counter is zero or timeout
 // returns true if timeout
 func (w *Wait) WaitWithTimeout(timeout time.Duration) bool {
-	c := make(chan bool)
+	c := make(chan bool, 1)
 	go func() {
 		defer close(c)
 		w.wg.Wait()


### PR DESCRIPTION
Currently a non-buffer channel is used to control timeout processing, which means that if an event is not processed before the time expires, there will be no receiver for the channel. This causes the goroutine to block forever at the `c <- true` step, leading to goroutine leak. The above is also mentioned in issue  #30 .

We can verify the occurrence of the above scenario with the following code:
```go
func main() {
	go func() {
		for {
			fmt.Printf("NumGoroutine = %d\n", runtime.NumGoroutine())
			time.Sleep(time.Second)
		}
	}()

	for {
		work()
	}
}

func work() {
	w := Wait{}
	defer w.Done()

	w.Add(1)
	w.WaitWithTimeout(100 * time.Microsecond)
}
```

Running the above code will result in the output:
```
NumGoroutine = 3
NumGoroutine = 68
NumGoroutine = 134
NumGoroutine = 199
NumGoroutine = 264
NumGoroutine = 330
NumGoroutine = 397
NumGoroutine = 461
```

The easiest way to handle this is to change the channel to a buffer channel with 1 buffer.