### PR TITLE
fix: fix the bug for DiscardMulti which returns wrong reply.

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -147,7 +147,7 @@ func DiscardMulti(conn redis.Connection) redis.Reply {
 	}
 	conn.ClearQueuedCmds()
 	conn.SetMultiState(false)
-	return reply.MakeQueuedReply()
+	return reply.MakeOkReply()
 }
 
 // GetUndoLogs return rollback commands


### PR DESCRIPTION
当前DISCARD命令返回值为QUEUED，而Redis协议DISCARD的返回值为OK。
此处代码的返回值应该改为reply.MakeOkReply()