### PR TITLE
Feat: add HStrlen command.

### DIFF
--- a/cluster/router.go
+++ b/cluster/router.go
@@ -60,6 +60,7 @@ func makeRouter() map[string]CmdFunc {
 	routerMap["hexists"] = defaultFunc
 	routerMap["hdel"] = defaultFunc
 	routerMap["hlen"] = defaultFunc
+	routerMap["hstrlen"] = defaultFunc
 	routerMap["hmget"] = defaultFunc
 	routerMap["hmset"] = defaultFunc
 	routerMap["hkeys"] = defaultFunc

--- a/commands.md
+++ b/commands.md
@@ -53,6 +53,7 @@
     - hexists
     - hdel
     - hlen
+    - hstrlen
     - hmget
     - hmset
     - hkeys

--- a/database/hash.go
+++ b/database/hash.go
@@ -186,6 +186,28 @@ func execHLen(db *DB, args [][]byte) redis.Reply {
 	return protocol.MakeIntReply(int64(dict.Len()))
 }
 
+// execHStrlen Returns the string length of the value associated with field in the hash stored at key.
+// If the key or the field do not exist, 0 is returned.
+func execHStrlen(db *DB, args [][]byte) redis.Reply {
+	key := string(args[0])
+	field := string(args[1])
+
+	dict, errReply := db.getAsDict(key)
+	if errReply != nil {
+		return errReply
+	}
+	if dict == nil {
+		return protocol.MakeIntReply(0)
+	}
+
+	raw, exists := dict.Get(field)
+	if exists {
+		value, _ := raw.([]byte)
+		return protocol.MakeIntReply(int64(len(value)))
+	}
+	return protocol.MakeIntReply(0)
+}
+
 // execHMSet sets multi fields in hash table
 func execHMSet(db *DB, args [][]byte) redis.Reply {
 	// parse args
@@ -405,6 +427,7 @@ func init() {
 	RegisterCommand("HExists", execHExists, readFirstKey, nil, 3)
 	RegisterCommand("HDel", execHDel, writeFirstKey, undoHDel, -3)
 	RegisterCommand("HLen", execHLen, readFirstKey, nil, 2)
+	RegisterCommand("HStrlen", execHStrlen, readFirstKey, nil, 3)
 	RegisterCommand("HMSet", execHMSet, writeFirstKey, undoHMSet, -4)
 	RegisterCommand("HMGet", execHMGet, readFirstKey, nil, -3)
 	RegisterCommand("HGet", execHGet, readFirstKey, nil, -3)

--- a/database/hash_test.go
+++ b/database/hash_test.go
@@ -26,7 +26,7 @@ func TestHSet(t *testing.T) {
 		}
 	}
 
-	// test hget and hexists
+	// test hget, hexists and hstrlen
 	for field, v := range values {
 		actual := testDB.Exec(nil, utils.ToCmdLine("hget", key, field))
 		expected := protocol.MakeBulkReply(v)
@@ -36,6 +36,11 @@ func TestHSet(t *testing.T) {
 		actual = testDB.Exec(nil, utils.ToCmdLine("hexists", key, field))
 		if intResult, _ := actual.(*protocol.IntReply); intResult.Code != int64(1) {
 			t.Error(fmt.Sprintf("expected %d, actually %d", 1, intResult.Code))
+		}
+
+		actual = testDB.Exec(nil, utils.ToCmdLine("hstrlen", key, field))
+		if intResult, _ := actual.(*protocol.IntReply); intResult.Code != int64(len(v)) {
+			t.Error(fmt.Sprintf("expected %d, actually %d", int64(len(v)), intResult.Code))
 		}
 	}
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
@@ -13,11 +12,9 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=


### PR DESCRIPTION
This is a command that was updated in redis 3.2.0.
Time complexity: O(1).
Usage: hstrlen key field

Return
Integer reply: the string length of the value associated with field, or zero when field is not present in the hash or key does not exist at all.

Examples:
```
0.0.0.0:6399> hset testhash A 12345678
(integer) 1
0.0.0.0:6399> hstrlen testhash A
(integer) 8
0.0.0.0:6399> hstrlen non_exist_key A
(integer) 0
0.0.0.0:6399> hstrlen testhash non_exist_field
(integer) 0
```
