### PR TITLE
Feat:Add hrandfield Command

### DIFF
--- a/cluster/router.go
+++ b/cluster/router.go
@@ -67,6 +67,7 @@ func makeRouter() map[string]CmdFunc {
 	routerMap["hgetall"] = defaultFunc
 	routerMap["hincrby"] = defaultFunc
 	routerMap["hincrbyfloat"] = defaultFunc
+	routerMap["hrandfield"] = defaultFunc
 
 	routerMap["sadd"] = defaultFunc
 	routerMap["sismember"] = defaultFunc

--- a/commands.md
+++ b/commands.md
@@ -60,6 +60,7 @@
     - hgetall
     - hincrby
     - hincrbyfloat
+    - hrandfield
 - Set
     - sadd
     - sismember


### PR DESCRIPTION
This is a command added in Redis version 6.2.0.
Time complexity: O(N) where N is the number of fields returned
Usage:  HRANDFIELD key [ count [WITHVALUES]]

When called with just the key argument, return a random field from the hash value stored at key.

If the provided count argument is positive, return an array of distinct fields. The array's length is either count or the hash's number of fields (HLEN), whichever is lower.

If called with a negative count, the behavior changes and the command is allowed to return the same field multiple times. In this case, the number of returned fields is the absolute value of the specified count.

The optional WITHVALUES modifier changes the reply so it includes the respective values of the randomly selected hash fields.


Example(Using this PR version):
```
127.0.0.1:6399> hmset test a 1 b 2 c 3
OK
127.0.0.1:6399> hgetall test
1) "b"
2) "2"
3) "c"
4) "3"
5) "a"
6) "1"
127.0.0.1:6399> hrandfield test
1) "a"
127.0.0.1:6399> hrandfield test 5
1) "a"
2) "b"
3) "c"
127.0.0.1:6399> hrandfield test -5
1) "a"
2) "a"
3) "c"
4) "a"
5) "a"
127.0.0.1:6399> hrandfield test 5 withvalues
1) "c"
2) "3"
3) "a"
4) "1"
5) "b"
6) "2"
127.0.0.1:6399> hrandfield test -5 withvalues
 1) "a"
 2) "1"
 3) "a"
 4) "1"
 5) "a"
 6) "1"
 7) "a"
 8) "1"
 9) "a"
10) "1"
```

After add hrandfield and hstrlen([#PR 60](https://github.com/HDT3213/godis/pull/60)),the godis hash command will now be the same as the latest redis(just the number,not the detail).
添加了 hrandfield 和 #PR 60 的 hstrlen 后，godis 就具有了与 redis 的 hash 相同的命令（细节上并不完全相同）。