### PR TITLE
Feat: Add two string commands: "GETEX" and "GETDEL"

### DIFF
--- a/cluster/router.go
+++ b/cluster/router.go
@@ -34,7 +34,9 @@ func makeRouter() map[string]CmdFunc {
 	routerMap["mget"] = MGet
 	routerMap["msetnx"] = MSetNX
 	routerMap["get"] = defaultFunc
+	routerMap["getex"] = defaultFunc
 	routerMap["getset"] = defaultFunc
+	routerMap["getdel"] = defaultFunc
 	routerMap["incr"] = defaultFunc
 	routerMap["incrby"] = defaultFunc
 	routerMap["incrbyfloat"] = defaultFunc

--- a/commands.md
+++ b/commands.md
@@ -27,7 +27,9 @@
     - mget
     - msetnx
     - get
+    - getex
     - getset
+    - getdel
     - incr
     - incrby
     - incrbyfloat

--- a/database/string.go
+++ b/database/string.go
@@ -409,7 +409,9 @@ func execGetDel(db *DB, args [][]byte) redis.Reply {
 		return new(protocol.NullBulkReply)
 	}
 	db.Remove(key)
-	db.addAof(utils.ToCmdLine3("getdel", args...))
+
+	// We convert to del command to write aof
+	db.addAof(utils.ToCmdLine3("del", args...))
 	return protocol.MakeBulkReply(old)
 }
 


### PR DESCRIPTION
Both commands are available in Redis 6.2.0.

GETEX:
Usage: GETEX key [ EX seconds | PX milliseconds | PERSIST]
Time complexity: O(1)

Get the value of key and optionally set its expiration. GETEX is similar to GET, but is a write command with additional options.
this command return the value of key, or nil when key does not exist,or an error if the key's value type isn't a string.

Options
The GETEX command supports a set of options that modify its behavior:
- EX seconds -- Set the specified expire time, in seconds.
- PX milliseconds -- Set the specified expire time, in milliseconds.
- PERSIST -- Remove the time to live associated with the key.

Note that there are two more additional options "EXAT" and "PXAT" in redis, but they are not yet supported here.

GETDEL:
Usage: GETDEL key
Time complexity: O(1)

Get the value of key and delete the key. This command is similar to GET, except for the fact that it also deletes the key on success (if and only if the key's value type is a string).
this command return the value of key, nil when key does not exist, or an error if the key's value type isn't a string.

Examples("GETEX" and "GETDEL" by this PR Version):
```
127.0.0.1:6399> set key value
OK
127.0.0.1:6399> getex key ex 60
"value"
127.0.0.1:6399> ttl key
(integer) 56
127.0.0.1:6399> getex key persist
"value"
127.0.0.1:6399> ttl key
(integer) -1
127.0.0.1:6399> getex key px 60000
"value"
127.0.0.1:6399> ttl key
(integer) 56
127.0.0.1:6399> getdel key
"value"
127.0.0.1:6399> get key
(nil)
```

