### PR TITLE
Convert GETSET to SET command to write  AOF

### DIFF
--- a/database/string.go
+++ b/database/string.go
@@ -317,7 +317,7 @@ func execGetSet(db *DB, args [][]byte) redis.Reply {
 
 	db.PutEntity(key, &database.DataEntity{Data: value})
 	db.Persist(key) // override ttl
-	db.addAof(utils.ToCmdLine3("getset", args...))
+	db.addAof(utils.ToCmdLine3("set", args...))
 	if old == nil {
 		return new(protocol.NullBulkReply)
 	}


### PR DESCRIPTION
We only need the set command in AOF.
This is the GetSet implementation in redis.
```
void getsetCommand(client *c) {
    if (getGenericCommand(c) == C_ERR) return;
    c->argv[2] = tryObjectEncoding(c->argv[2]);
    setKey(c,c->db,c->argv[1],c->argv[2],0);
    notifyKeyspaceEvent(NOTIFY_STRING,"set",c->argv[1],c->db->id);
    server.dirty++;

    /* Propagate as SET command */
    rewriteClientCommandArgument(c,0,shared.set);
}
```