### PR TITLE
Feat:Add "copy" command

### DIFF
--- a/cluster/copy.go
+++ b/cluster/copy.go
@@ -1,0 +1,115 @@
+package cluster
+
+import (
+	"github.com/hdt3213/godis/interface/redis"
+	"github.com/hdt3213/godis/lib/utils"
+	"github.com/hdt3213/godis/redis/protocol"
+	"strconv"
+	"strings"
+)
+
+const copyToAnotherDBErr = "ERR Copying to another database is not allowed in cluster mode"
+const noReplace = "NoReplace"
+const useReplace = "UseReplace"
+
+// Copy copies the value stored at the source key to the destination key.
+// the origin and the destination must within the same node.
+func Copy(cluster *Cluster, c redis.Connection, args [][]byte) redis.Reply {
+	if len(args) < 3 {
+		return protocol.MakeErrReply("ERR wrong number of arguments for 'copy' command")
+	}
+	srcKey := string(args[1])
+	destKey := string(args[2])
+	srcNode := cluster.peerPicker.PickNode(srcKey)
+	destNode := cluster.peerPicker.PickNode(destKey)
+	replaceFlag := noReplace
+	if len(args) > 3 {
+		for i := 3; i < len(args); i++ {
+			arg := strings.ToLower(string(args[i]))
+			if arg == "db" {
+				return protocol.MakeErrReply(copyToAnotherDBErr)
+			} else if arg == "replace" {
+				replaceFlag = useReplace
+			} else {
+				return protocol.MakeSyntaxErrReply()
+			}
+		}
+	}
+
+	if srcNode == destNode {
+		return cluster.relay(srcNode, c, args)
+	}
+	groupMap := map[string][]string{
+		srcNode:  {srcKey},
+		destNode: {destKey},
+	}
+
+	txID := cluster.idGenerator.NextID()
+	txIDStr := strconv.FormatInt(txID, 10)
+	// prepare Copy from
+	srcPrepareResp := cluster.relayPrepare(srcNode, c, makeArgs("Prepare", txIDStr, "CopyFrom", srcKey))
+	if protocol.IsErrorReply(srcPrepareResp) {
+		// rollback src node
+		requestRollback(cluster, c, txID, map[string][]string{srcNode: {srcKey}})
+		return srcPrepareResp
+	}
+	srcPrepareMBR, ok := srcPrepareResp.(*protocol.MultiBulkReply)
+	if !ok || len(srcPrepareMBR.Args) < 2 {
+		requestRollback(cluster, c, txID, map[string][]string{srcNode: {srcKey}})
+		return protocol.MakeErrReply("ERR invalid prepare response")
+	}
+	// prepare Copy to
+	destPrepareResp := cluster.relayPrepare(destNode, c, utils.ToCmdLine3("Prepare", []byte(txIDStr),
+		[]byte("CopyTo"), []byte(destKey), srcPrepareMBR.Args[0], srcPrepareMBR.Args[1], []byte(replaceFlag)))
+	if protocol.IsErrorReply(destPrepareResp) {
+		// rollback src node
+		requestRollback(cluster, c, txID, groupMap)
+		return destPrepareResp
+	}
+	if _, errReply := requestCommit(cluster, c, txID, groupMap); errReply != nil {
+		requestRollback(cluster, c, txID, groupMap)
+		return errReply
+	}
+	return protocol.MakeIntReply(1)
+}
+
+// prepareCopyFrom is prepare-function for CopyFrom, see prepareFuncMap
+func prepareCopyFrom(cluster *Cluster, conn redis.Connection, cmdLine CmdLine) redis.Reply {
+	if len(cmdLine) != 2 {
+		return protocol.MakeArgNumErrReply("CopyFrom")
+	}
+	key := string(cmdLine[1])
+	existResp := cluster.db.ExecWithLock(conn, utils.ToCmdLine("Exists", key))
+	if protocol.IsErrorReply(existResp) {
+		return existResp
+	}
+	existIntResp := existResp.(*protocol.IntReply)
+	if existIntResp.Code == 0 {
+		return protocol.MakeErrReply("ERR no such key")
+	}
+	return cluster.db.ExecWithLock(conn, utils.ToCmdLine2("DumpKey", key))
+}
+
+func prepareCopyTo(cluster *Cluster, conn redis.Connection, cmdLine CmdLine) redis.Reply {
+	if len(cmdLine) != 5 {
+		return protocol.MakeArgNumErrReply("CopyTo")
+	}
+	key := string(cmdLine[1])
+	replaceFlag := string(cmdLine[4])
+	existResp := cluster.db.ExecWithLock(conn, utils.ToCmdLine("Exists", key))
+	if protocol.IsErrorReply(existResp) {
+		return existResp
+	}
+	existIntResp := existResp.(*protocol.IntReply)
+	if existIntResp.Code == 1 {
+		if replaceFlag == noReplace {
+			return protocol.MakeErrReply(keyExistsErr)
+		}
+	}
+	return protocol.MakeOkReply()
+}
+
+func init() {
+	registerPrepareFunc("CopyFrom", prepareCopyFrom)
+	registerPrepareFunc("CopyTo", prepareCopyTo)
+}

--- a/cluster/copy_test.go
+++ b/cluster/copy_test.go
@@ -1,0 +1,120 @@
+package cluster
+
+import (
+	"github.com/hdt3213/godis/lib/utils"
+	"github.com/hdt3213/godis/redis/connection"
+	"github.com/hdt3213/godis/redis/protocol/asserts"
+	"testing"
+)
+
+func TestCopy(t *testing.T) {
+	conn := new(connection.FakeConn)
+	testNodeA.db.Exec(conn, utils.ToCmdLine("FlushALL"))
+
+	// cross node copy
+	srcKey := testNodeA.self + utils.RandString(10)
+	value := utils.RandString(10)
+	destKey := testNodeB.self + utils.RandString(10)
+	testNodeA.db.Exec(conn, utils.ToCmdLine("SET", srcKey, value))
+	result := Copy(testNodeA, conn, utils.ToCmdLine("COPY", srcKey, destKey))
+	asserts.AssertIntReply(t, result, 1)
+	result = testNodeA.db.Exec(conn, utils.ToCmdLine("GET", srcKey))
+	asserts.AssertBulkReply(t, result, value)
+	result = testNodeB.db.Exec(conn, utils.ToCmdLine("GET", destKey))
+	asserts.AssertBulkReply(t, result, value)
+	// key exists
+	result = Copy(testNodeA, conn, utils.ToCmdLine("COPY", srcKey, destKey))
+	asserts.AssertErrReply(t, result, keyExistsErr)
+	// replace
+	value = utils.RandString(10)
+	testNodeA.db.Exec(conn, utils.ToCmdLine("SET", srcKey, value))
+	result = Copy(testNodeA, conn, utils.ToCmdLine("COPY", srcKey, destKey, "REPLACE"))
+	asserts.AssertIntReply(t, result, 1)
+	result = testNodeA.db.Exec(conn, utils.ToCmdLine("GET", srcKey))
+	asserts.AssertBulkReply(t, result, value)
+	result = testNodeB.db.Exec(conn, utils.ToCmdLine("GET", destKey))
+	asserts.AssertBulkReply(t, result, value)
+	// test copy expire time
+	testNodeA.db.Exec(conn, utils.ToCmdLine("SET", srcKey, value, "EX", "1000"))
+	result = Copy(testNodeA, conn, utils.ToCmdLine("COPY", srcKey, destKey, "REPLACE"))
+	asserts.AssertIntReply(t, result, 1)
+	result = testNodeA.db.Exec(conn, utils.ToCmdLine("TTL", srcKey))
+	asserts.AssertIntReplyGreaterThan(t, result, 0)
+	result = testNodeB.db.Exec(conn, utils.ToCmdLine("TTL", destKey))
+	asserts.AssertIntReplyGreaterThan(t, result, 0)
+
+	// same node copy
+	srcKey = testNodeA.self + utils.RandString(10)
+	value = utils.RandString(10)
+	destKey = srcKey + utils.RandString(2)
+	testNodeA.db.Exec(conn, utils.ToCmdLine("SET", srcKey, value))
+	result = Copy(testNodeA, conn, utils.ToCmdLine("COPY", srcKey, destKey))
+	asserts.AssertIntReply(t, result, 1)
+	result = testNodeA.db.Exec(conn, utils.ToCmdLine("GET", srcKey))
+	asserts.AssertBulkReply(t, result, value)
+	result = testNodeA.db.Exec(conn, utils.ToCmdLine("GET", destKey))
+	asserts.AssertBulkReply(t, result, value)
+	// key exists
+	result = Copy(testNodeA, conn, utils.ToCmdLine("COPY", srcKey, destKey))
+	asserts.AssertIntReply(t, result, 0)
+	// replace
+	value = utils.RandString(10)
+	testNodeA.db.Exec(conn, utils.ToCmdLine("SET", srcKey, value))
+	result = Copy(testNodeA, conn, utils.ToCmdLine("COPY", srcKey, destKey, "REPLACE"))
+	asserts.AssertIntReply(t, result, 1)
+	result = testNodeA.db.Exec(conn, utils.ToCmdLine("GET", srcKey))
+	asserts.AssertBulkReply(t, result, value)
+	result = testNodeA.db.Exec(conn, utils.ToCmdLine("GET", destKey))
+	asserts.AssertBulkReply(t, result, value)
+	// test copy expire time
+	testNodeA.db.Exec(conn, utils.ToCmdLine("SET", srcKey, value, "EX", "1000"))
+	result = Copy(testNodeA, conn, utils.ToCmdLine("COPY", srcKey, destKey, "REPLACE"))
+	asserts.AssertIntReply(t, result, 1)
+	result = testNodeA.db.Exec(conn, utils.ToCmdLine("TTL", srcKey))
+	asserts.AssertIntReplyGreaterThan(t, result, 0)
+	result = testNodeA.db.Exec(conn, utils.ToCmdLine("TTL", destKey))
+	asserts.AssertIntReplyGreaterThan(t, result, 0)
+
+	// test src prepare failed
+	*simulateATimout = true
+	srcKey = testNodeA.self + utils.RandString(10)
+	destKey = testNodeB.self + utils.RandString(10) // route to testNodeB, see mockPicker.PickNode
+	value = utils.RandString(10)
+	testNodeA.db.Exec(conn, utils.ToCmdLine("SET", srcKey, value, "ex", "1000"))
+	result = Rename(testNodeB, conn, utils.ToCmdLine("RENAME", srcKey, destKey))
+	asserts.AssertErrReply(t, result, "ERR timeout")
+	result = testNodeA.db.Exec(conn, utils.ToCmdLine("EXISTS", srcKey))
+	asserts.AssertIntReply(t, result, 1)
+	result = testNodeA.db.Exec(conn, utils.ToCmdLine("TTL", srcKey))
+	asserts.AssertIntReplyGreaterThan(t, result, 0)
+	result = testNodeB.db.Exec(conn, utils.ToCmdLine("EXISTS", destKey))
+	asserts.AssertIntReply(t, result, 0)
+	*simulateATimout = false
+
+	// test dest prepare failed
+	*simulateBTimout = true
+	srcKey = testNodeA.self + utils.RandString(10)
+	destKey = testNodeB.self + utils.RandString(10) // route to testNodeB, see mockPicker.PickNode
+	value = utils.RandString(10)
+	testNodeA.db.Exec(conn, utils.ToCmdLine("SET", srcKey, value, "ex", "1000"))
+	result = Rename(testNodeA, conn, utils.ToCmdLine("COPY", srcKey, destKey))
+	asserts.AssertErrReply(t, result, "ERR timeout")
+	result = testNodeA.db.Exec(conn, utils.ToCmdLine("EXISTS", srcKey))
+	asserts.AssertIntReply(t, result, 1)
+	result = testNodeA.db.Exec(conn, utils.ToCmdLine("TTL", srcKey))
+	asserts.AssertIntReplyGreaterThan(t, result, 0)
+	result = testNodeB.db.Exec(conn, utils.ToCmdLine("EXISTS", destKey))
+	asserts.AssertIntReply(t, result, 0)
+	*simulateBTimout = false
+
+	// Copying to another database
+	srcKey = testNodeA.self + utils.RandString(10)
+	value = utils.RandString(10)
+	destKey = srcKey + utils.RandString(2)
+	testNodeA.db.Exec(conn, utils.ToCmdLine("SET", srcKey, value))
+	result = Copy(testNodeA, conn, utils.ToCmdLine("COPY", srcKey, destKey, "db", "1"))
+	asserts.AssertErrReply(t, result, copyToAnotherDBErr)
+
+	result = Copy(testNodeA, conn, utils.ToCmdLine("COPY", srcKey))
+	asserts.AssertErrReply(t, result, "ERR wrong number of arguments for 'copy' command")
+}

--- a/cluster/router.go
+++ b/cluster/router.go
@@ -25,6 +25,7 @@ func makeRouter() map[string]CmdFunc {
 	routerMap["type"] = defaultFunc
 	routerMap["rename"] = Rename
 	routerMap["renamenx"] = RenameNx
+	routerMap["copy"] = Copy
 
 	routerMap["set"] = defaultFunc
 	routerMap["setnx"] = defaultFunc

--- a/cluster/utils.go
+++ b/cluster/utils.go
@@ -42,7 +42,7 @@ func execSelect(c redis.Connection, args [][]byte) redis.Reply {
 	if err != nil {
 		return protocol.MakeErrReply("ERR invalid DB index")
 	}
-	if dbIndex >= config.Properties.Databases {
+	if dbIndex >= config.Properties.Databases || dbIndex < 0 {
 		return protocol.MakeErrReply("ERR DB index is out of range")
 	}
 	c.SelectDB(dbIndex)

--- a/commands.md
+++ b/commands.md
@@ -18,6 +18,7 @@
     - flushall
     - keys
     - bgrewriteaof
+    - copy
 - String
     - set
     - setnx

--- a/database/database.go
+++ b/database/database.go
@@ -122,6 +122,11 @@ func (mdb *MultiDB) Exec(c redis.Connection, cmdLine [][]byte) (result redis.Rep
 			return protocol.MakeArgNumErrReply("select")
 		}
 		return execSelect(c, mdb, cmdLine[1:])
+	} else if cmdName == "copy" {
+		if len(cmdLine) < 3 {
+			return protocol.MakeArgNumErrReply("copy")
+		}
+		return execCopy(mdb, c, cmdLine[1:])
 	}
 	// todo: support multi database transaction
 
@@ -151,7 +156,7 @@ func execSelect(c redis.Connection, mdb *MultiDB, args [][]byte) redis.Reply {
 	if err != nil {
 		return protocol.MakeErrReply("ERR invalid DB index")
 	}
-	if dbIndex >= len(mdb.dbSet) {
+	if dbIndex >= len(mdb.dbSet) || dbIndex < 0 {
 		return protocol.MakeErrReply("ERR DB index is out of range")
 	}
 	c.SelectDB(dbIndex)


### PR DESCRIPTION
**COPY source destination [DB destination-db] [REPLACE]**
Available since: 6.2.0
Time complexity: O(N) worst case for collections, where N is the number of nested items. O(1) for string values.

This command copies the value stored at the source key to the destination key.
By default, the destination key is created in the logical database used by the connection. The DB option allows specifying an alternative logical database index for the destination key.
The command returns an error when the destination key already exists. The REPLACE option removes the destination key before copying the value to it.

Return
Integer reply, specifically:
1 if source was copied.
0 if source was not copied.


Above from https://redis.io/commands/copy/

Examples(By this pr version):
```
127.0.0.1:6399> keys *
(empty array)
127.0.0.1:6399> set key1 a(db0)
OK

// Copy in the same DB by default
127.0.0.1:6399> copy key1 key2
(integer) 1
127.0.0.1:6399> keys *
1) "key2"
2) "key1"
127.0.0.1:6399> get key2
"a(db0)"

// source and destination objects are the same
127.0.0.1:6399> copy key1 key1
(error) ERR source and destination objects are the same

// Test "destination-db" option
// Copy key1(db0) -> key1(db1)
127.0.0.1:6399> copy key1 key1 DB 1
(integer) 1
127.0.0.1:6399> select 1
OK
127.0.0.1:6399[1]> keys *
1) "key1"
127.0.0.1:6399[1]> get key1
"a(db0)"

// destination key exist and no "replace" option
127.0.0.1:6399[1]> set key2 b(db1)
OK
127.0.0.1:6399[1]> copy key2 key2 DB 0
(integer) 0
127.0.0.1:6399[1]> select 0
OK
127.0.0.1:6399> get key2
"a(db0)"

// Test "replace" option
127.0.0.1:6399> select 1
OK
127.0.0.1:6399[1]> copy key2 key2 DB 0 REPLACE
(integer) 1
127.0.0.1:6399[1]> select 0
OK
127.0.0.1:6399> get key2
"b(db1)"

// Copy a key with expire time
127.0.0.1:6399> setex key1 30 a(db0)
OK
127.0.0.1:6399> copy key1 key3
(integer) 1
127.0.0.1:6399> ttl key1
(integer) 21
127.0.0.1:6399> ttl key3
(integer) 20

// Test some error case
127.0.0.1:6399> copy key1 key3 db 16
(error) ERR DB index is out of range
127.0.0.1:6399> copy key1 key3 db -1
(error) ERR DB index is out of range
127.0.0.1:6399> copy key1 key3 db err
(error) Err syntax error

127.0.0.1:6399> set key1 a(db0)
OK

// If we have more than one "db", the last one will be used (the same as redis)
127.0.0.1:6399> copy key1 key2 db 0 db 1 db 3
(integer) 1
127.0.0.1:6399> select 3
OK
127.0.0.1:6399[3]> get key2
"a(db0)"
```
By the way, this PR also fixes the negative number out of bounds error case of the select command.