### PR TITLE
Small bugfix on datastructure/dict/simple.go

### DIFF
--- a/datastruct/dict/simple.go
+++ b/datastruct/dict/simple.go
@@ -106,7 +106,7 @@ func (dict *SimpleDict) RandomDistinctKeys(limit int) []string {
 	result := make([]string, size)
 	i := 0
 	for k := range dict.m {
-		if i == limit {
+		if i == size {
 			break
 		}
 		result[i] = k


### PR DESCRIPTION
Just a small bug which may cause IndexOutOfBound in some cases.
The break condition should be ```i == size```,  because ```result := make([]string, size)``` set the size of ```result``` as ```size```