### PR TITLE
perf: slightly optimize the channel type to save memory space in file lib/sync/wait/wait.go

### DIFF
--- a/lib/sync/wait/wait.go
+++ b/lib/sync/wait/wait.go
@@ -28,11 +28,11 @@ func (w *Wait) Wait() {
 // WaitWithTimeout blocks until the WaitGroup counter is zero or timeout
 // returns true if timeout
 func (w *Wait) WaitWithTimeout(timeout time.Duration) bool {
-	c := make(chan bool, 1)
+	c := make(chan struct{}, 1)
 	go func() {
 		defer close(c)
 		w.Wait()
-		c <- true
+		c <- struct{}{}
 	}()
 	select {
 	case <-c:


### PR DESCRIPTION
perf: slightly optimize the channel type to save memory space in file lib/sync/wait/wait.go
Limited ability, hope to make it better~