### PR TITLE
perf: slightly optimize config/config.go & fix: channel`s closing parser/parser.go

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -50,7 +50,7 @@ func parse(src io.Reader) *ServerProperties {
 	scanner := bufio.NewScanner(src)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if len(line) > 0 && line[0] == '#' {
+		if len(line) > 0 && strings.TrimLeft(line, " ")[0] == '#' {
 			continue
 		}
 		pivot := strings.IndexAny(line, " ")
@@ -72,7 +72,7 @@ func parse(src io.Reader) *ServerProperties {
 		field := t.Elem().Field(i)
 		fieldVal := v.Elem().Field(i)
 		key, ok := field.Tag.Lookup("cfg")
-		if !ok {
+		if !ok || strings.TrimLeft(key, " ") == "" {
 			key = field.Name
 		}
 		value, ok := rawMap[strings.ToLower(key)]

--- a/lib/sync/wait/wait.go
+++ b/lib/sync/wait/wait.go
@@ -28,11 +28,11 @@ func (w *Wait) Wait() {
 // WaitWithTimeout blocks until the WaitGroup counter is zero or timeout
 // returns true if timeout
 func (w *Wait) WaitWithTimeout(timeout time.Duration) bool {
-	c := make(chan bool, 1)
+	c := make(chan struct{}, 1)
 	go func() {
 		defer close(c)
 		w.Wait()
-		c <- true
+		c <- struct{}{}
 	}()
 	select {
 	case <-c:

--- a/redis/parser/parser.go
+++ b/redis/parser/parser.go
@@ -76,6 +76,7 @@ func parse0(reader io.Reader, ch chan<- *Payload) {
 	defer func() {
 		if err := recover(); err != nil {
 			logger.Error(err, string(debug.Stack()))
+			ch <- nil
 		}
 	}()
 

--- a/redis/parser/parser.go
+++ b/redis/parser/parser.go
@@ -76,7 +76,7 @@ func parse0(reader io.Reader, ch chan<- *Payload) {
 	defer func() {
 		if err := recover(); err != nil {
 			logger.Error(err, string(debug.Stack()))
-			ch <- nil
+			close(ch)
 		}
 	}()
 


### PR DESCRIPTION
perf: slightly optimize config/config.go

- Exclude the struct tag is space
- Exclude configuration file comment, which is starting with space

fix: in the case of panic unexpected happened in the method parse0 of parser/parser.go, closing of the channel is needed to prevent the program from getting stuck~

Limited ability, hope to make it better~