### PR TITLE
perf: slightly optimize the value`s type of map 

### DIFF
--- a/redis/server/server.go
+++ b/redis/server/server.go
@@ -61,7 +61,7 @@ func (h *Handler) Handle(ctx context.Context, conn net.Conn) {
 	}
 
 	client := connection.NewConn(conn)
-	h.activeConn.Store(client, 1)
+	h.activeConn.Store(client, struct{}{})
 
 	ch := parser.ParseStream(conn)
 	for payload := range ch {


### PR DESCRIPTION
perf: slightly optimize the value`s type of map to save memory space in file redis/server/server.go

Note: I'm not sure if setting the map\`s value to the int 1 is useful, but if the original purpose is using the dictionary as a "set" type, then I think it's the map`s value is "struct{}{}" better.

If my idea is incomplete, I will close this PR~ 
Have a nice day~

Limited ability, hope to make it better~