### PR TITLE
fix: fix a deadlock issue caused by unclosing RUnlock

### DIFF
--- a/aof/aof.go
+++ b/aof/aof.go
@@ -82,6 +82,7 @@ func (handler *Handler) handleAof() {
 			_, err := handler.aofFile.Write(data)
 			if err != nil {
 				logger.Warn(err)
+				handler.pausingAof.RUnlock()
 				continue // skip this command
 			}
 			handler.currentDB = p.dbIndex


### PR DESCRIPTION
#### fix: fix a deadlock issue caused by unclosing RUnlock

By the way, there is another alternative, using lambda function, which I didn't commit because it changed the style of the code,  if you prefer, I can submit it, as follows：
```golang
	for p := range handler.aofChan {
		func() {
			handler.pausingAof.RLock() // prevent other goroutines from pausing aof
			defer handler.pausingAof.RUnlock()

			if p.dbIndex != handler.currentDB {
				// 	select db
				data := reply.MakeMultiBulkReply(utils.ToCmdLine("SELECT", strconv.Itoa(p.dbIndex))).ToBytes()
				_, err := handler.aofFile.Write(data)
				if err != nil {
					logger.Warn(err)
					return // skip this command
				}
				handler.currentDB = p.dbIndex
			}
			data := reply.MakeMultiBulkReply(p.cmdLine).ToBytes()
			_, err := handler.aofFile.Write(data)
			if err != nil {
				logger.Warn(err)
			}
		}()
		handler.aofFinished <- struct{}{}
	}
```

Limited ability, make it better~