### PR TITLE
fix: rewrite.go FinishRewrite method failed to rename aofFile

### DIFF
--- a/aof/rewrite.go
+++ b/aof/rewrite.go
@@ -117,9 +117,7 @@ func (handler *Handler) FinishRewrite(ctx *RewriteCtx) {
 		logger.Error("open aofFilename failed: " + err.Error())
 		return
 	}
-	defer func() {
-		_ = src.Close()
-	}()
+
 	_, err = src.Seek(ctx.fileSize, 0)
 	if err != nil {
 		logger.Error("seek failed: " + err.Error())

--- a/aof/rewrite.go
+++ b/aof/rewrite.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hdt3213/godis/lib/utils"
 	"github.com/hdt3213/godis/redis/protocol"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
@@ -93,7 +92,8 @@ func (handler *Handler) StartRewrite() (*RewriteCtx, error) {
 	filesize := fileInfo.Size()
 
 	// create tmp file
-	file, err := ioutil.TempFile("", "*.aof")
+	//file, err := ioutil.TempFile("", "*.aof")
+	file, err := os.Create("tmpAofFile.aof")
 	if err != nil {
 		logger.Warn("tmp file create failed")
 		return nil, err
@@ -142,6 +142,8 @@ func (handler *Handler) FinishRewrite(ctx *RewriteCtx) {
 
 	// replace current aof file by tmp file
 	_ = handler.aofFile.Close()
+	_ = src.Close()
+	_ = tmpFile.Close()
 	_ = os.Rename(tmpFile.Name(), handler.aofFilename)
 
 	// reopen aof file for further write

--- a/aof/rewrite.go
+++ b/aof/rewrite.go
@@ -142,7 +142,10 @@ func (handler *Handler) FinishRewrite(ctx *RewriteCtx) {
 	_ = handler.aofFile.Close()
 	_ = src.Close()
 	_ = tmpFile.Close()
-	_ = os.Rename(tmpFile.Name(), handler.aofFilename)
+	err = os.Rename(tmpFile.Name(), handler.aofFilename)
+	if err != nil {
+		logger.Warn("update aof file failed: " + err.Error())
+	}
 
 	// reopen aof file for further write
 	aofFile, err := os.OpenFile(handler.aofFilename, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0600)

--- a/redis.conf
+++ b/redis.conf
@@ -2,6 +2,6 @@ bind 0.0.0.0
 port 6399
 maxclients 128
 
-#appendonly no
-#appendfilename appendonly.aof
+appendonly yes
+appendfilename appendonly.aof
 #dbfilename test.rdb

--- a/redis.conf
+++ b/redis.conf
@@ -2,6 +2,6 @@ bind 0.0.0.0
 port 6399
 maxclients 128
 
-appendonly yes
-appendfilename appendonly.aof
+#appendonly yes
+#appendfilename appendonly.aof
 #dbfilename test.rdb


### PR DESCRIPTION
解决 [issues/114](https://github.com/HDT3213/godis/issues/114) 的bug。
关闭没有及时关闭的文件，同时让tmpAofFile.aof创建在项目目录之下，原代码tmpAof是创建在C盘的temp缓存文件夹中。这样会导致跨文件夹移动失败