### PR TITLE
bugfix:convert the range of k from [1,17] to [1,16]

### DIFF
--- a/datastruct/sortedset/skiplist.go
+++ b/datastruct/sortedset/skiplist.go
@@ -58,7 +58,7 @@ func makeSkiplist() *skiplist {
 func randomLevel() int16 {
 	total := uint64(1)<<uint64(maxLevel) - 1
 	k := rand.Uint64() % total
-	return maxLevel - int16(bits.Len64(k)) + 1
+	return maxLevel - int16(bits.Len64(k+1)) + 1
 }
 
 func (skiplist *skiplist) insert(member string, score float64) *node {


### PR DESCRIPTION
There is an exception in skiplist. We should convert the range of k from [1,17] to [1,16].