### PR TITLE
Pre-allocate geohash slice memory

### DIFF
--- a/lib/geohash/geohash.go
+++ b/lib/geohash/geohash.go
@@ -1,7 +1,6 @@
 package geohash
 
 import (
-	"bytes"
 	"encoding/base32"
 	"encoding/binary"
 )
@@ -18,10 +17,8 @@ func encode0(latitude, longitude float64, bitSize uint) ([]byte, [2][2]float64) 
 		{-90, 90},   // lat
 	}
 	pos := [2]float64{longitude, latitude}
-	hash := &bytes.Buffer{}
-	bit := 0
+	hash := make([]byte, bitSize>>3)
 	var precision uint = 0
-	code := uint8(0)
 	for precision < bitSize {
 		for direction, val := range pos {
 			mid := (box[direction][0] + box[direction][1]) / 2
@@ -29,13 +26,7 @@ func encode0(latitude, longitude float64, bitSize uint) ([]byte, [2][2]float64) 
 				box[direction][1] = mid
 			} else {
 				box[direction][0] = mid
-				code |= bits[bit]
-			}
-			bit++
-			if bit == 8 {
-				hash.WriteByte(code)
-				bit = 0
-				code = 0
+				hash[precision>>3] |= 1 << (7 - precision&7)
 			}
 			precision++
 			if precision == bitSize {
@@ -43,11 +34,8 @@ func encode0(latitude, longitude float64, bitSize uint) ([]byte, [2][2]float64) 
 			}
 		}
 	}
-	// precision%8 > 0
-	if code > 0 {
-		hash.WriteByte(code)
-	}
-	return hash.Bytes(), box
+
+	return hash, box
 }
 
 // Encode converts latitude and longitude to uint64 geohash code


### PR DESCRIPTION
geohash的长度是确定的，因此可以直接创建出geohash的切片。另外bytes.Buffer第一次会创建容量为64的byte silce，对于8Byte的geohash存在浪费。