### PR TITLE
bugfix: server stuck after signal received

### DIFF
--- a/tcp/server.go
+++ b/tcp/server.go
@@ -51,7 +51,7 @@ func ListenAndServeWithSignal(cfg *Config, handler tcp.Handler) error {
 // ListenAndServe binds port and handle requests, blocking until close
 func ListenAndServe(listener net.Listener, handler tcp.Handler, closeChan <-chan struct{}) {
 	// listen signal
-	errCh := make(chan error)
+	errCh := make(chan error, 1)
 	defer close(errCh)
 	go func() {
 		select {
@@ -70,10 +70,7 @@ func ListenAndServe(listener net.Listener, handler tcp.Handler, closeChan <-chan
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
-			select {
-			case errCh <- err:
-			default:
-			}
+			errCh <- err
 			break
 		}
 		// handle

--- a/tcp/server.go
+++ b/tcp/server.go
@@ -70,7 +70,10 @@ func ListenAndServe(listener net.Listener, handler tcp.Handler, closeChan <-chan
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
-			errCh <- err
+			select {
+			case errCh <- err:
+			default:
+			}
 			break
 		}
 		// handle


### PR DESCRIPTION
信号触发以后`errCh`这个channel就没有接收者了，继续使用`errCh <- err`导致阻塞，从而使服务无法退出。