### PR TITLE
fix /redis/protocol/errors

### DIFF
--- a/redis/protocol/errors.go
+++ b/redis/protocol/errors.go
@@ -82,5 +82,5 @@ func (r *ProtocolErrReply) ToBytes() []byte {
 }
 
 func (r *ProtocolErrReply) Error() string {
-	return "ERR Protocol error: '" + r.Msg
+	return "ERR Protocol error '" + r.Msg + "' command"
 }


### PR DESCRIPTION
the line 85 has some error
I change    
return "ERR Protocol error: '" + r.Msg -->
return "ERR Protocol error '" + r.Msg + "' command"
I think you may forget copy all the code.
It's a small error,I just change one line.