### PR TITLE
fix concurrent_test.go t.Error

### DIFF
--- a/datastruct/dict/concurrent_test.go
+++ b/datastruct/dict/concurrent_test.go
@@ -230,6 +230,7 @@ func TestConcurrentRemove(t *testing.T) {
 	}
 }
 
+//change t.Error remove->forEach
 func TestConcurrentForEach(t *testing.T) {
 	d := MakeConcurrent(0)
 	size := 100
@@ -243,13 +244,13 @@ func TestConcurrentForEach(t *testing.T) {
 		intVal, _ := value.(int)
 		expectedKey := "k" + strconv.Itoa(intVal)
 		if key != expectedKey {
-			t.Error("remove test failed: expected " + expectedKey + ", actual: " + key)
+			t.Error("forEach test failed: expected " + expectedKey + ", actual: " + key)
 		}
 		i++
 		return true
 	})
 	if i != size {
-		t.Error("remove test failed: expected " + strconv.Itoa(size) + ", actual: " + strconv.Itoa(i))
+		t.Error("forEach test failed: expected " + strconv.Itoa(size) + ", actual: " + strconv.Itoa(i))
 	}
 }
 

--- a/redis/protocol/errors.go
+++ b/redis/protocol/errors.go
@@ -82,5 +82,5 @@ func (r *ProtocolErrReply) ToBytes() []byte {
 }
 
 func (r *ProtocolErrReply) Error() string {
-	return "ERR Protocol error: '" + r.Msg
+	return "ERR Protocol error '" + r.Msg + "' command"
 }


### PR DESCRIPTION
In func TestConcurrentForEach(t *testing.T)
the t.Error("remove test failed: expected " + expectedKey + ", actual: " + key)
forget to change the ’remove‘ -> ’forEach‘
Just a little change