### PR TITLE
Update set_test.go fix a little error

### DIFF
--- a/database/set_test.go
+++ b/database/set_test.go
@@ -130,7 +130,7 @@ func TestSInter(t *testing.T) {
 	key1 := utils.RandString(10)
 	testDB.Exec(nil, utils.ToCmdLine("sadd", key1, "a", "b"))
 	key2 := utils.RandString(10)
-	testDB.Exec(nil, utils.ToCmdLine("sadd", key1, "1", "2"))
+	testDB.Exec(nil, utils.ToCmdLine("sadd", key2, "1", "2"))
 	result = testDB.Exec(nil, utils.ToCmdLine("sinter", key0, key1, key2))
 	asserts.AssertMultiBulkReplySize(t, result, 0)
 	result = testDB.Exec(nil, utils.ToCmdLine("sinter", key1, key2))


### PR DESCRIPTION
I wonder that this was an little mistake because exec key1 for 2 times doesn't reach the purpose of test sinter here