### PR TITLE
bugfix: Fix the issue with the result format returned by the randomkey command

### DIFF
--- a/database/string.go
+++ b/database/string.go
@@ -831,8 +831,7 @@ func getRandomKey(db *DB, args [][]byte) redis.Reply {
 	if len(k) == 0 {
 		return &protocol.NullBulkReply{}
 	}
-	var key []byte
-	return protocol.MakeBulkReply(strconv.AppendQuote(key, k[0]))
+	return protocol.MakeBulkReply([]byte(k[0]))
 }
 
 func init() {


### PR DESCRIPTION
Fix the issue with the result format returned by the randomkey command.
## error:
```sh
127.0.0.1:6399> set k v
OK

127.0.0.1:6399> RANDOMKEY
"\"k\""
```

## correct：
```sh
127.0.0.1:6399> set k v
OK
127.0.0.1:6399> RANDOMKEY
"k"
```