### PR TITLE
fix issue #238

### DIFF
--- a/lib/geohash/neighbor.go
+++ b/lib/geohash/neighbor.go
@@ -1,6 +1,8 @@
 package geohash
 
-import "math"
+import (
+	"math"
+)
 
 const (
 	dr          = math.Pi / 180.0
@@ -86,8 +88,11 @@ func GetNeighbours(latitude, longitude, radiusMeters float64) [][2]uint64 {
 	precision := estimatePrecisionByRadius(radiusMeters, latitude)
 
 	center, box := encode0(latitude, longitude, precision)
-	height := box[0][1] - box[0][0]
-	width := box[1][1] - box[1][0]
+	// Width represents the range difference in the longitudinal direction
+	// Height represents the range difference in the latitudinal direction
+	// Conforming to the conventional representation of geographic coordinates.
+	width := box[0][1] - box[0][0]
+	height := box[1][1] - box[1][0]
 	centerLng := (box[0][1] + box[0][0]) / 2
 	centerLat := (box[1][1] + box[1][0]) / 2
 	maxLat := ensureValidLat(centerLat + height)


### PR DESCRIPTION
在每次循环中，对于经度（对应 box[0][0] 和 box[0][1]）和纬度（对应 box[1][0] 和 box[1][1]）这两个维度，都是按照相同的逻辑去不断地二等分范围。
每一次循环迭代，都是通过计算当前维度范围的中间值 mid，然后根据坐标值与 mid 的比较结果来更新该维度范围的边界（也就是 box 中对应维度的两个值）。这种二等分的更新方式是完全对称的操作，在经过相同次数的迭代（由 bitSize 决定迭代次数）后，经度和纬度这两个维度的范围缩小比例是一样的，所以最终它们的范围差值（也就是 box[0][1] - box[0][0] 和 box[1][1] - box[1][0]）会相同，即height和width相同。
导致即使此处相较于常规的经纬度逻辑不同也仍然可以正确计算出结果。