### PR TITLE
optimize del in cluster

### DIFF
--- a/cluster/commands/del.go
+++ b/cluster/commands/del.go
@@ -25,7 +25,6 @@ func execDel(cluster *core.Cluster, c redis.Connection, cmdLine CmdLine) redis.R
 		return protocol.MakeArgNumErrReply("del")
 	}
 	var keys []string
-	keyValues := make(map[string][]byte)
 	for i := 1; i < len(cmdLine); i++ {
 		key := string(cmdLine[i])
 		keys = append(keys, key)
@@ -44,8 +43,7 @@ func execDel(cluster *core.Cluster, c redis.Connection, cmdLine CmdLine) redis.R
 	for node, keys := range routeMap {
 		nodeCmdLine := utils.ToCmdLine("del")
 		for _, key := range keys {
-			val := keyValues[key]
-			nodeCmdLine = append(nodeCmdLine, []byte(key), val)
+			nodeCmdLine = append(nodeCmdLine, []byte(key))
 		}
 		cmdLineMap[node] = nodeCmdLine
 	}

--- a/cluster/core/tcc.go
+++ b/cluster/core/tcc.go
@@ -55,7 +55,7 @@ func execPrepare(cluster *Cluster, c redis.Connection, cmdLine CmdLine) redis.Re
 	tx := cluster.transactions.txs[txId]
 	if tx != nil {
 		cluster.transactions.mu.Unlock()
-		return protocol.MakeErrReply("transction existed")
+		return protocol.MakeErrReply("transaction existed")
 	}
 	tx = &TCC{}
 	cluster.transactions.txs[txId] = tx
@@ -92,11 +92,10 @@ func execCommit(cluster *Cluster, c redis.Connection, cmdLine CmdLine) redis.Rep
 
 	cluster.transactions.mu.Lock()
 	tx := cluster.transactions.txs[txId]
-	if tx == nil {
-		cluster.transactions.mu.Unlock()
-		return protocol.MakeErrReply("transction not found")
-	}
 	cluster.transactions.mu.Unlock()
+	if tx == nil {
+		return protocol.MakeErrReply("transaction not found")
+	}
 
 	resp := cluster.db.ExecWithLock(c, tx.realCmdLine)
 
@@ -127,11 +126,10 @@ func execRollback(cluster *Cluster, c redis.Connection, cmdLine CmdLine) redis.R
 	// get transaction
 	cluster.transactions.mu.Lock()
 	tx := cluster.transactions.txs[txId]
-	if tx == nil {
-		cluster.transactions.mu.Unlock()
-		return protocol.MakeErrReply("transction not found")
-	}
 	cluster.transactions.mu.Unlock()
+	if tx == nil {
+		return protocol.MakeErrReply("transaction not found")
+	}
 
 	// rollback
 	if !tx.hasLock {


### PR DESCRIPTION
1. cluster del 这里的操作会导致发给其他节点的 del 命令最后多出一个 nil，貌似是没有必要的
![image](https://github.com/user-attachments/assets/351adfea-f20a-4233-bb8f-318e7a574f2a)
2. 优化了一下 tcc 中的代码