### PR TITLE
fix(aof): 在退出时关闭ticker

### DIFF
--- a/aof/aof.go
+++ b/aof/aof.go
@@ -275,8 +275,9 @@ func (persister *Persister) Close() {
 
 // fsyncEverySecond fsync aof file every second
 func (persister *Persister) fsyncEverySecond() {
-	ticker := time.NewTicker(time.Second)
 	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:


### PR DESCRIPTION
程序退出时 ticker 未关闭，按 Go 官方文档要求，`Stop()` 必须在不再使用 ticker 时调用